### PR TITLE
vmware_vsphere: fix sourcetype program matches

### DIFF
--- a/package/etc/conf.d/conflib/syslog/app-syslog-vmware_vsphere.conf
+++ b/package/etc/conf.d/conflib/syslog/app-syslog-vmware_vsphere.conf
@@ -23,7 +23,8 @@ filter syslog-vmware_vsphere-esx-pgm{
     or program("crond", type(string) flags(ignore-case,prefix))
     or program("kmxa", type(string) flags(ignore-case,prefix))
     or program("crx-cli", type(string) flags(ignore-case,prefix))
-    or program("backup.sh*", type(string) flags(ignore-case,prefix))
+    or program("backup.sh", type(string) flags(ignore-case,prefix))
+    or program("auto-backup.sh", type(string) flags(ignore-case,prefix))
     or program("configStoreBackup", type(string) flags(ignore-case,prefix))
     or program("heartbeat", type(string) flags(ignore-case,prefix))
 


### PR DESCRIPTION
remove * from backup, type(string) does not interpret it as a wildcard, but instead as a string.

Add match for auto-backup.sh program